### PR TITLE
fix java.lang.NoClassDefFoundError: net/skinsrestorer/shared/utils/ReflectionUtil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>net.skinsrestorer</groupId>
 			<artifactId>skinsrestorer</artifactId>
-			<version>14.1.0-SNAPSHOT</version>
+			<version>14.1.6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.Nan1t</groupId>

--- a/src/main/java/ai/akemi/bluemapofflineskinsupport/BlueMapOfflineSkinSupport.java
+++ b/src/main/java/ai/akemi/bluemapofflineskinsupport/BlueMapOfflineSkinSupport.java
@@ -19,11 +19,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Objects;
 import java.util.UUID;
 import javax.imageio.ImageIO;
 
 import net.skinsrestorer.api.SkinsRestorerAPI;
-import net.skinsrestorer.shared.utils.ReflectionUtil;
 import ru.csm.api.services.SkinsAPI;
 
 public class BlueMapOfflineSkinSupport extends JavaPlugin {
@@ -54,7 +54,7 @@ public class BlueMapOfflineSkinSupport extends JavaPlugin {
 			skinsRestorerAPI = SkinsRestorerAPI.getApi();
 		} else if (getServer().getPluginManager().getPlugin("CustomSkinsManager") != null) {
 			getLogger().info("CustomSkinsManager detected! Using CustomSkinsManager API...");
-			customSkinsManagerAPI = getServer().getServicesManager().getRegistration(SkinsAPI.class).getProvider();
+			customSkinsManagerAPI = Objects.requireNonNull(getServer().getServicesManager().getRegistration(SkinsAPI.class)).getProvider();
 		}
 
 		if (skinsRestorerAPI != null) {
@@ -121,7 +121,7 @@ public class BlueMapOfflineSkinSupport extends JavaPlugin {
 				try {
 					logInfo(((preferences.getBoolean("alwaysUseSkinsRestorerForSkinLookup")) ? "Using the SkinsRestorer API to derive " + targetPlayer.getName() + "'s true skin." : "The player " + targetPlayer.getName() + " has a custom skin set via SkinsRestorer! Proceeding to use the SkinsRestorer API to derive their true skin..."));
 					String skinsRestorerSkinName = ((skinsRestorerSkinName = getSkinsRestorerAPI().getSkinName(targetPlayer.getName())) != null) ? skinsRestorerSkinName : targetPlayer.getName();
-					String skinsRestorerSkinBase64Blob = ReflectionUtil.invokeMethod(getSkinsRestorerAPI().getSkinData(skinsRestorerSkinName), "getValue").toString();
+					String skinsRestorerSkinBase64Blob = getSkinsRestorerAPI().getSkinData(skinsRestorerSkinName).getValue();
 					logInfo("skinsRestorerSkinBase64Blob for " + targetPlayer.getName() + " is " + skinsRestorerSkinBase64Blob);
 					String skinTextureURL = deriveSkinTextureURLStringFromBase64Blob(skinsRestorerSkinBase64Blob);
 					logInfo("skinTextureURL for " + targetPlayer.getName() + "'s skin is " + skinTextureURL + "!");
@@ -165,7 +165,7 @@ public class BlueMapOfflineSkinSupport extends JavaPlugin {
 	}
 
 	public String getConfiguredWebrootDirectoryWithoutTrailingSlash() {
-		return new File(preferences.getString("webroot")).getAbsolutePath();
+		return new File(Objects.requireNonNull(preferences.getString("webroot"))).getAbsolutePath();
 	}
 
 	public String getConfiguredWebrootDirectoryWithTrailingSlash() {


### PR DESCRIPTION
I fix it by removing ReflectionUtil all together. according to this https://docs.oracle.com/javase/tutorial/reflect/ "Reflection is powerful, but should not be used indiscriminately. If it is possible to perform an operation without using reflection, then it is preferable to avoid using it" and because the output of getValue() is already a string, my guess is using ReflectionUtil is too redundant, so I remove it